### PR TITLE
Update backend-node.yml

### DIFF
--- a/.github/workflows/backend-node.yml
+++ b/.github/workflows/backend-node.yml
@@ -2,10 +2,9 @@
 name: Backend (Node)
 
 on:
-  push:
-    branches: [ "main" ]
-    paths: [ "backend/**", ".github/workflows/backend-node.yml" ]
   pull_request:
+    branches: [ "main" ]          # corre SIEMPRE en PR → el ruleset no queda "Expected"
+  push:
     branches: [ "main" ]
     paths: [ "backend/**", ".github/workflows/backend-node.yml" ]
 


### PR DESCRIPTION
Solucionar problemas ocasionados al correr las pruebas de la regla de Protección de la Rama Principal. En pull_request corran SIEMPRE y mantener los paths solo en push (para no gastar CI en cada commit a main).